### PR TITLE
Keep subcommand ordering from cobra

### DIFF
--- a/gencodo.go
+++ b/gencodo.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -208,12 +207,6 @@ func genDocsTree(
 			return nil
 		}
 
-		for _, subCmd := range c.Commands() {
-			if err := generateDocs(subCmd); err != nil {
-				return err
-			}
-		}
-
 		basename := strings.ReplaceAll(c.CommandPath(), " ", "-") + format.FileExtension()
 		filename := filepath.Join(dir, basename)
 		f, err := os.Create(filename)
@@ -230,6 +223,13 @@ func genDocsTree(
 		}
 
 		files = append(files, basename)
+
+		for _, subCmd := range c.Commands() {
+			if err := generateDocs(subCmd); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}
 
@@ -238,8 +238,6 @@ func genDocsTree(
 			return err
 		}
 	}
-
-	sort.Strings(files)
 
 	data := struct {
 		Files []string


### PR DESCRIPTION
> [!Important]
> This is based on https://github.com/canonical/gencodo/pull/13, please review and merge that PR first.

Cobra's `Command.Commands()` method orders the returned subcommands alphabetically by default. That can be disabled via `cobra.EnableCommandSorting = false`, in which case the ordering in which commands are added via `Command.AddCommand()` is retained.

Let's keep that ordering in the generated docs.
